### PR TITLE
fix: handle accountId header in LibreLinkUpFollower service

### DIFF
--- a/mobile/src/main/java/sk/trupici/gwatch/wear/followers/LibreLinkUpFollowerService.java
+++ b/mobile/src/main/java/sk/trupici/gwatch/wear/followers/LibreLinkUpFollowerService.java
@@ -136,13 +136,9 @@ public class LibreLinkUpFollowerService extends FollowerService {
     @Override
     protected List<GlucosePacket> getServerValues(Context context) {
         if (authResult == null) {
-            Log.i(GWatchApplication.LOG_TAG, "PR CHANGES - authResult is null, authenticate!");
             authResult = authenticate(context);
-
-            Log.i(GWatchApplication.LOG_TAG, "PR CHANGES - Return authenticate: " + authResult.token + " ;accountId: " + authResult.accountId);
         }
         if (authResult != null) {
-            Log.i(GWatchApplication.LOG_TAG, "PR CHANGES - Authentication is ready: " + authResult.token + " ;accountId: " + authResult.accountId);
             if (connectionId == null) {
                 connectionId = getConnectionId(context);
             }
@@ -190,7 +186,7 @@ public class LibreLinkUpFollowerService extends FollowerService {
         return new Request.Builder()
                 .addHeader("User-Agent", USER_AGENT)
                 .addHeader("product", "llu.ios")
-                .addHeader("version", "4.7.0")
+                .addHeader("version", "4.12.0")
                 .addHeader("Accept", "application/json")
                 .addHeader("Pragma", "no-cache")
                 ;
@@ -228,9 +224,7 @@ public class LibreLinkUpFollowerService extends FollowerService {
                 Log.i(GWatchApplication.LOG_TAG, "LibreLinkUp data received: " + receivedData);
                 AuthResult authResult = extractToken(receivedData);
                 if (authResult == null) {
-                    Log.i(GWatchApplication.LOG_TAG, "PR CHANGES - authResult is null in authenticate()");
                     if (parseRedirect(receivedData)) {
-                        Log.i(GWatchApplication.LOG_TAG, "PR CHANGES - authResult is null in authenticate(), parseRedirect ok");
                         return authenticate(context);
                     }
                 }
@@ -262,8 +256,6 @@ public class LibreLinkUpFollowerService extends FollowerService {
             String url = getServerUrl() + "/llu/connections";
 
             UiUtils.showMessage(context, context.getString(R.string.follower_session_request, SRC_LABEL));
-
-            Log.i(GWatchApplication.LOG_TAG, "PR CHANGES - get connection id using new AccountId header: " + authResult.accountId);
 
             request = createRequestBuilder()
                     .addHeader("Authorization", "Bearer " + authResult.token)
@@ -312,8 +304,6 @@ public class LibreLinkUpFollowerService extends FollowerService {
             String url = getServerUrl() + "/llu/connections/" + connectionId + "/graph";
 
             UiUtils.showMessage(context, context.getString(R.string.follower_data_request, SRC_LABEL));
-
-            Log.i(GWatchApplication.LOG_TAG, "PR CHANGES - get Bg Data using new AccountId header: " + authResult.accountId);
 
             request = createRequestBuilder()
                     .addHeader("Authorization", "Bearer " + authResult.token)

--- a/mobile/src/main/java/sk/trupici/gwatch/wear/followers/LibreLinkUpFollowerService.java
+++ b/mobile/src/main/java/sk/trupici/gwatch/wear/followers/LibreLinkUpFollowerService.java
@@ -35,7 +35,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
 

--- a/mobile/src/main/java/sk/trupici/gwatch/wear/followers/LibreLinkUpFollowerService.java
+++ b/mobile/src/main/java/sk/trupici/gwatch/wear/followers/LibreLinkUpFollowerService.java
@@ -267,7 +267,7 @@ public class LibreLinkUpFollowerService extends FollowerService {
 
             request = createRequestBuilder()
                     .addHeader("Authorization", "Bearer " + authResult.token)
-                    .addHeader("AccountId", authResult.accountId)
+                    .addHeader("Account-Id", authResult.accountId)
                     .url(url)
                     .build();
         } catch (Exception e) {
@@ -317,7 +317,7 @@ public class LibreLinkUpFollowerService extends FollowerService {
 
             request = createRequestBuilder()
                     .addHeader("Authorization", "Bearer " + authResult.token)
-                    .addHeader("AccountId", authResult.accountId)
+                    .addHeader("Account-Id", authResult.accountId)
                     .url(url)
                     .build();
         } catch (Exception e) {


### PR DESCRIPTION
After the release of LibreLinkUp api 4.12.0 it is necessary to retrieve the account id during authentication and send it as a header in subsequent requests.

https://github.com/trupici/G-Watch-Wear/issues/47